### PR TITLE
Fix markdown test failure

### DIFF
--- a/.github/workflows/pull_request_ci.yml
+++ b/.github/workflows/pull_request_ci.yml
@@ -2,6 +2,7 @@ name: Pull request checks
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   check-unique-standard-names:

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -1236,6 +1236,8 @@ Standard / required CCPP variables
     * `integer(kind=)`: units = mm
 * `index_of_water_vegetation_category`: Index of water vegetation category
     * `integer(kind=)`: units = index
+* `filename_of_micm_configuration`: Filename of micm configuration
+    * `character(kind=len=*)`: units = none
 ## GFS_typedefs_GFS_interstitial_type
 * `cloud_ice_mixing_ratio_wrt_moist_air_interstitial`: Cloud ice mixing ratio wrt moist air interstitial
     * `real(kind=kind_phys)`: units = kg kg-1

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -1803,7 +1803,7 @@
          <type kind="" units="index">integer</type>
       </standard_name>
       <standard_name name="filename_of_micm_configuration">
-         <type kind="len=64" units="none">character</type>
+         <type kind="len=*" units="none">character</type>
       </standard_name>
    </section>
    <section name="GFS_typedefs_GFS_interstitial_type">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -1802,6 +1802,9 @@
       <standard_name name="index_of_water_vegetation_category">
          <type kind="" units="index">integer</type>
       </standard_name>
+      <standard_name name="filename_of_micm_configuration">
+         <type kind="len=64" units="none">character</type>
+      </standard_name>
    </section>
    <section name="GFS_typedefs_GFS_interstitial_type">
       <standard_name name="cloud_ice_mixing_ratio_wrt_moist_air_interstitial">


### PR DESCRIPTION
Merged in the ESCOMP repo's main branch to fix the current CI test failure.  Also added a `workflow_dispatch` option to the Github Actions workflow, which could help debug test failures in the future.